### PR TITLE
Add decimal conversion for amounts in transactions

### DIFF
--- a/elixir/lib/homework_web/resolvers/companies_resolver.ex
+++ b/elixir/lib/homework_web/resolvers/companies_resolver.ex
@@ -7,7 +7,7 @@ defmodule HomeworkWeb.Resolvers.CompaniesResolver do
     """
     def get_available_credit(company) do
         transactions = Transactions.get_transactions_company!(company.id)
-        Map.put(company, :available_credit, Enum.reduce(transactions, 0, fn(transaction), total_amount -> if transaction.debit do company.credit_line - round(transaction.amount/100) + total_amount else company.credit_line + round(transaction.amount/100) + total_amount end end))
+        Map.put(company, :available_credit, Enum.reduce(transactions, 0, fn(transaction), total_amount -> if transaction.debit do company.credit_line - transaction.amount + total_amount else company.credit_line + transaction.amount + total_amount end end))
     end
 
     @doc """

--- a/elixir/lib/homework_web/resolvers/transactions_resolver.ex
+++ b/elixir/lib/homework_web/resolvers/transactions_resolver.ex
@@ -5,11 +5,20 @@ defmodule HomeworkWeb.Resolvers.TransactionsResolver do
   alias Homework.Companies
   alias HomeworkWeb.Resolvers.CompaniesResolver
 
+  def convert_to_dollar(transaction) do
+    %{transaction | amount: transaction.amount / 100}
+  end
+
+  def convert_to_cents(transaction) do
+    %{transaction | amount: transaction.amount * 100}
+  end
+
   @doc """
   Get a list of transcations
   """
   def transactions(_root, args, _info) do
-    {:ok, Transactions.list_transactions(args)}
+    # Convert to decimal
+    {:ok, Enum.map(Transactions.list_transactions(args), &convert_to_dollar/1)}
   end
 
   @doc """
@@ -38,7 +47,7 @@ defmodule HomeworkWeb.Resolvers.TransactionsResolver do
   Create a new transaction
   """
   def create_transaction(_root, args, _info) do
-    case Transactions.create_transaction(args) do
+    case Transactions.create_transaction(convert_to_cents(args)) do
       {:ok, transaction} ->
         {:ok, transaction}
 
@@ -53,7 +62,7 @@ defmodule HomeworkWeb.Resolvers.TransactionsResolver do
   def update_transaction(_root, %{id: id} = args, _info) do
     transaction = Transactions.get_transaction!(id)
 
-    case Transactions.update_transaction(transaction, args) do
+    case Transactions.update_transaction(transaction, convert_to_cents(args)) do
       {:ok, transaction} ->
         {:ok, transaction}
 

--- a/elixir/lib/homework_web/schemas/transactions_schema.ex
+++ b/elixir/lib/homework_web/schemas/transactions_schema.ex
@@ -9,7 +9,7 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
   object :transaction do
     field(:id, non_null(:id))
     field(:user_id, :id)
-    field(:amount, :integer)
+    field(:amount, :float)
     field(:credit, :boolean)
     field(:debit, :boolean)
     field(:description, :string)
@@ -38,7 +38,7 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
       arg(:merchant_id, non_null(:id))
       arg(:company_id, non_null(:id))
       @desc "amount is in cents"
-      arg(:amount, non_null(:integer))
+      arg(:amount, non_null(:float))
       arg(:credit, non_null(:boolean))
       arg(:debit, non_null(:boolean))
       arg(:description, non_null(:string))
@@ -53,7 +53,7 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
       arg(:merchant_id, non_null(:id))
       arg(:company_id, non_null(:id))
       @desc "amount is in cents"
-      arg(:amount, non_null(:integer))
+      arg(:amount, non_null(:float))
       arg(:credit, non_null(:boolean))
       arg(:debit, non_null(:boolean))
       arg(:description, non_null(:string))

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -67,7 +67,7 @@ merchant_data = [
 transaction_data = [
     %{
         id: "6ad67dea-0ca8-4b75-84e0-0ce702a7e611",
-        amount: 1234,
+        amount: 123456,
         credit: true,
         debit: false,
         description: "Return of product",
@@ -77,7 +77,7 @@ transaction_data = [
     },
     %{
         id: "40754a8d-be15-4c43-85d4-eb8157c109b4",
-        amount: 25000,
+        amount: 2500065,
         credit: false,
         debit: true,
         description: "Groceries",


### PR DESCRIPTION
Changed resolvers to accept decimal amounts and convert them into cents to store in the DB.
Update seed file with more numbers at end of amount for testing